### PR TITLE
Fix README example code typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var tagsPromise = htmlPromise.then(parseHtml)
 var linksPromise = tagsPromise.then(getLinks)
 
 // and then parses the actual urls from the links (using parseUrlsFromLinks())
-var urlsPromise = linksPromise.then(linksPromise)
+var urlsPromise = linksPromise.then(parseUrlsFromLinks)
 
 // finally, we have a promise that should only provide us with the urls and will run once all the previous steps have ran
 urlsPromise.then(function (urls) {


### PR DESCRIPTION
Hello @azulus, 

Please review the following commits I made in branch 'kylehardgrave-fix-readme-typo'.

497c161683451eb014c1360279d05b5e94497897 (2013-06-04 16:41:25 -0700)
Corrected function name typo in README

R=@azulus
VISIBLE_CHANGES=Fix README example code typo
