### PR TITLE
Bump version to 0.3.0. Biggest changes are to fcall/nfcall API changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kew"
   , "description": "a lightweight promise library for node"
-  , "version": "0.2.2"
+  , "version": "0.3.0"
   , "homepage": "https://github.com/Obvious/kew"
   , "authors": [
       "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"
@@ -18,8 +18,8 @@
   , "dependencies": {
     }
   , "devDependencies": {
-        "q": "0.9.6",
-        "nodeunit": "0.7.4"
+        "q": "0.9.7",
+        "nodeunit": "0.8.1"
     }
   , "scripts": {
       "test": "./node_modules/nodeunit/bin/nodeunit test"


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'nick-version'.

12fc7c7b45d402fa7a22a6a8f317bd9938400727 (2013-11-01 11:59:51 -0400)
Bump version to 0.3.0. Biggest changes are to fcall/nfcall API changes

Check list:

R=@nicks
VISIBLE_CHANGES=Bump version to 0.3.0. Biggest changes are to fcall/nfcall API changes
