### PR TITLE
kew: Fix Closure annotations to match usage.

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -1,9 +1,14 @@
+/** @typedef {function(?, ?)} */
+var OnSuccessCallbackType;
+/** @typedef {function(!Error, ?)} */
+var OnFailCallbackType;
+
 /**
  * An object representing a "promise" for a future value
  *
- * @param {?function(*, *)=} onSuccess a function to handle successful
+ * @param {?OnSuccessCallbackType=} onSuccess a function to handle successful
  *     resolution of this promise
- * @param {function(!Error, *)=} onFail a function to handle failed
+ * @param {OnFailCallbackType=} onFail a function to handle failed
  *     resolution of this promise
  * @constructor
  */
@@ -136,8 +141,8 @@ Promise.prototype.reject = function (e) {
  * resolves. Allows for an optional second callback to handle the failure
  * case.
  *
- * @param {?function(*, *)} onSuccess
- * @param {function(!Error, *)=} onFail
+ * @param {?OnSuccessCallbackType} onSuccess
+ * @param {OnFailCallbackType=} onFail
  * @return {!Promise} returns a new promise with the output of the onSuccess or
  *     onFail handler
  */
@@ -154,7 +159,7 @@ Promise.prototype.then = function (onSuccess, onFail) {
 /**
  * Provide a callback to be called whenever this promise is rejected
  *
- * @param {function(!Error, *=)} onFail
+ * @param {OnFailCallbackType} onFail
  * @return {!Promise} returns a new promise with the output of the onFail handler
  */
 Promise.prototype.fail = function (onFail) {
@@ -275,7 +280,7 @@ function resolver(deferred, err, data) {
  * Creates a node-style resolver for a deferred by wrapping
  * resolver()
  *
- * @return {function(Error, *)} node-style callback
+ * @return {function(?Error, *)} node-style callback
  */
 Promise.prototype.makeNodeResolver = function () {
   return resolver.bind(null, this)
@@ -349,8 +354,8 @@ function replaceEl(arr, idx, val) {
  * Takes in an array of promises or literals and returns a promise which returns
  * an array of values when all have resolved. If any fail, the promise fails.
  *
- * @param {!Array} promises
- * @return {!Promise.<!Array>}
+ * @param {!Array.<!Promise>} promises
+ * @return {!Promise}
  */
 function all(promises) {
   if (arguments.length != 1 || !Array.isArray(promises)) {
@@ -420,7 +425,7 @@ function delay(delayMs, returnVal) {
  * Return a promise which will evaluate the function fn in a future turn with
  * the provided args
  *
- * @param {function()} fn
+ * @param {function(...)} fn
  * @param {...} var_args a variable number of arguments
  * @return {!Promise}
  */
@@ -438,7 +443,7 @@ function fcall(fn, var_args) {
  * Returns a promise that will be invoked with the result of a node style
  * callback. All args to fn should be given except for the final callback arg
  *
- * @param {function()} fn
+ * @param {function(...)} fn
  * @param {...} var_args a variable number of arguments
  * @return {!Promise}
  */
@@ -454,7 +459,7 @@ function nfcall(fn, var_args) {
  * Binds a function to a scope with an optional number of curried arguments. Attaches
  * a node style callback as the last argument and returns a promise
  *
- * @param {function()} fn
+ * @param {function(...)} fn
  * @param {Object} scope
  * @param {...} var_args a variable number of arguments
  * @return {function(...)}: !Promise}

--- a/test/closure_test.js
+++ b/test/closure_test.js
@@ -1,0 +1,96 @@
+// java -jar ../../../third_party/closure-compiler/compiler.jar --language_in ECMASCRIPT5_STRICT --warning_level VERBOSE --compilation_level ADVANCED_OPTIMIZATIONS --externs ../../../login/externs_node.js --jscomp_error missingProperties --jscomp_error checkTypes kew.js kew_bad.js
+
+/**
+@param {Array} result
+*/
+var callback = function (result) {};
+
+/**
+@param {Array} result
+@param {Array} context
+*/
+var callbackWithContext = function (result, context) {};
+
+/**
+@param {Error} error
+*/
+var errorCallback = function (error) {};
+
+/**
+@param {Error} error
+@param {Array} context
+*/
+var errorCallbackWithContext = function (error, context) {};
+
+var exampleThen = function () {
+  var examplePromise = new Promise();
+  examplePromise.then(callback);
+  examplePromise.setContext([]);
+  examplePromise.then(callbackWithContext);
+
+  examplePromise.then(null, errorCallback);
+  examplePromise.then(null, errorCallbackWithContext);
+};
+
+var examplePromise = function () {
+  var promise = new Promise(callback);
+  promise = new Promise(callbackWithContext);
+  promise = new Promise(null, errorCallback);
+  promise = new Promise(null, errorCallbackWithContext);
+};
+
+var exampleFail = function () {
+  var promise = new Promise();
+  promise.fail(errorCallback);
+  promise.fail(errorCallbackWithContext);
+};
+
+var exampleResolver = function () {
+  var promise = new Promise();
+  var resolver = promise.makeNodeResolver();
+  // success
+  resolver(null, {});
+  // failure
+  resolver(new Error(), null);
+};
+
+var exampleAll = function () {
+  // should not compile, but does
+  all([5]);
+  all([{}]);
+  all([null]);
+  all([new Promise(), {}]);
+  all([new Promise(), null]);
+
+  // good
+  var promise = all([]);
+  all([new Promise(), new Promise()]);
+};
+
+var noArgsFunction = function () {};
+
+var exampleFcall = function () {
+  fcall(noArgsFunction);
+  fcall(callback, []);
+  fcall(callbackWithContext, [], 5);
+};
+
+/** @param {function(Error, *)} nodeCallback */
+var noArgsWithNodeCallback = function (nodeCallback) {};
+
+/**
+@param {!Array} argument
+@param {function(Error, *)} nodeCallback
+*/
+var oneArgWithNodeCallback = function (argument, nodeCallback) {};
+
+var exampleNfcall = function () {
+  var promise = nfcall(noArgsWithNodeCallback);
+  promise = nfcall(oneArgWithNodeCallback, []);
+};
+
+var exampleBindPromise = function () {
+  callback = bindPromise(noArgsWithNodeCallback, null);
+  callback = bindPromise(noArgsWithNodeCallback, {});
+  callback = bindPromise(oneArgWithNodeCallback, null, []);
+};

--- a/test/closure_test.sh
+++ b/test/closure_test.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if [ "$CLOSURE_JAR" == "" ]; then
+  echo "Error: Must set CLOSURE_JAR: CLOSURE_JAR=(compiler.jar) $0" > /dev/stderr
+  exit 1
+fi
+
+if [ ! \( -r "$CLOSURE_JAR" \) ]; then
+  echo "Error: CLOSURE_JAR=$CLOSURE_JAR is not readable" > /dev/stderr
+  exit 1
+fi
+
+SCRIPT_PATH="$( cd "$( dirname "$0" )" && pwd )"
+CLOSURE_STRICT="--language_in ECMASCRIPT5_STRICT --warning_level VERBOSE --compilation_level ADVANCED_OPTIMIZATIONS --jscomp_error checkTypes"
+
+java -jar $CLOSURE_JAR $CLOSURE_STRICT --externs $SCRIPT_PATH/externs_node.js $SCRIPT_PATH/../kew.js $SCRIPT_PATH/closure_test.js > /dev/null
+if [ $? -ne 0 ]; then
+  echo "FAILED"
+  exit 1
+else
+  echo "SUCCESS"
+fi

--- a/test/externs_node.js
+++ b/test/externs_node.js
@@ -1,0 +1,9 @@
+/* Node externs for Closure Compiler (just enough for kew.js). */
+
+/** @const */
+var module = {};
+
+/** @const */
+var process = {};
+/** @param {function()} callback */
+process.nextTick = function (callback) {};


### PR DESCRIPTION
I added a "test" for kew.js, since I needed to write it to understand what the type annotations should be. Questionable parts of this change I'm happy to revert:
- Using typedefs: This makes the annotations somewhat Closure-specific, and maybe a bit harder to read. I'm happy to expand them manually.
- Adding a weird test: This file should compile. Ideally this shouldn't be needed, but I needed it to understand what the annotations should be. Happy to revert.
