### PR TITLE
Fix Closure return type annotation for allSettled() and timeout()

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -266,7 +266,7 @@ Promise.prototype.end = function () {
  *
  * @param {number} timeoutMs The timeout threshold in msec
  * @param {string=} timeoutMsg error message
- * @returns a new promise with timeout
+ * @returns {!Promise} a new promise with timeout
  */
  Promise.prototype.timeout = function (timeoutMs, timeoutMsg) {
   var deferred = new Promise()
@@ -536,18 +536,18 @@ function all(promises) {
 }
 
 /**
- * Takes in an array of promises or literals and returns a promise which returns
- * an array of values when all have resolved or rejected.
+ * Takes in an array of promises or values and returns a promise that is
+ * fulfilled with an array of state objects when all have resolved or
+ * rejected. If a promise is resolved, its corresponding state object is
+ * {state: 'fulfilled', value: Object}; whereas if a promise is rejected, its
+ * corresponding state object is {state: 'rejected', reason: Object}.
  *
- * @param {!Array.<!Promise>} promises
- * @return {!Array.<Object>} The state of the promises. If a promise is resolved,
- *     its corresponding state object is {state: 'fulfilled', value: Object};
- *     whereas if a promise is rejected, its corresponding state object is
- *     {state: 'rejected', reason: Object}
+ * @param {!Array} promises or values
+ * @return {!Promise} Promise fulfilled with state objects for each input
  */
 function allSettled(promises) {
   if (!Array.isArray(promises)) {
-    throw Error('The input to "allSettled()" should be an array of Promise')
+    throw Error('The input to "allSettled()" should be an array of Promise or values')
   }
   if (!promises.length) return resolve([])
 

--- a/test/chain.js
+++ b/test/chain.js
@@ -373,6 +373,11 @@ exports.testAllSettled = function(test) {
       test.equals('oops', data[1].reason.message)
       test.equals('fulfilled', data[2].state)
       test.equals('just a string', data[2].value)
+    })
+
+  Q.allSettled([])
+    .then(function (data) {
+      test.equals(0, data.length)
       test.done()
     })
 }

--- a/test/closure_test.js
+++ b/test/closure_test.js
@@ -67,6 +67,19 @@ var exampleAll = function () {
   all([new Promise(), new Promise()]);
 };
 
+var exampleAllSettled = function () {
+  allSettled([]);
+  allSettled([5, {}, null, 'string']);
+  var promise = allSettled([new Promise()]);
+  promise.then(function(results){});
+};
+
+var exampleTimeout = function () {
+  var promise = new Promise();
+  var timeoutPromise = promise.timeout(50);
+  timeoutPromise.then(function(result){});
+};
+
 var noArgsFunction = function () {};
 
 var exampleFcall = function () {


### PR DESCRIPTION
The only "error" fix here is changing the types on allSettled. With the current master version, closure fails with two errors like:

/Users/ej/kew/test/../kew.js:571: ERROR - inconsistent return type
found   : Promise
required: Array.<(Object|null)>
  return promise

Commit description:

allSettled: Returns a Promise not an Array. Takes an Array containing any
  type of value. Fix Closure type annotations, doc comment, and exception
  error message
timeout: Add return type annotation (not strictly required)

chain.js: Add test for allSettled([])
closure_test.js: Add examples of calling allSettled() and timeout()
