### PR TITLE
mark Promise as a constructor so it can be used in type annotations

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -678,16 +678,17 @@ function bindPromise(fn, scope, var_args) {
 }
 
 module.exports = {
-    all: all
-  , bindPromise: bindPromise
-  , defer: defer
-  , delay: delay
-  , fcall: fcall
-  , isPromise: isPromise
-  , isPromiseLike: isPromiseLike
-  , nfcall: nfcall
-  , resolve: resolve
-  , reject: reject
-  , allSettled: allSettled
-  , Promise: Promise
+  all: all,
+  bindPromise: bindPromise,
+  defer: defer,
+  delay: delay,
+  fcall: fcall,
+  isPromise: isPromise,
+  isPromiseLike: isPromiseLike,
+  nfcall: nfcall,
+  resolve: resolve,
+  reject: reject,
+  allSettled: allSettled,
+  /** @constructor */
+  Promise: Promise
 }


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'nick-types'.

a1af31ad6e4414712ca1a36b86d02f3756595c33 (2014-03-05 19:59:03 -0500)
mark Promise as a constructor so it can be used in type annotations

R=@x-ma
