### PR TITLE
Kew should treat function objects as promise-like

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -516,7 +516,8 @@ function isPromise(obj) {
  * @return {boolean} Whether the object is a promise-like object
  */
 function isPromiseLike(obj) {
-  return typeof obj === 'object' && typeof obj.then === 'function'
+  return (typeof obj === 'object' || typeof obj === 'function') &&
+    typeof obj.then === 'function'
 }
 
 /**

--- a/test/static.js
+++ b/test/static.js
@@ -359,8 +359,14 @@ exports.testIsPromiseLike = function (test) {
       fn('like a promise, brah!')
     }
   }
+  var kewLikeFunction = function() {}
+  kewLikeFunction.then = function(fn) {
+    fn('like a promise, brah!')
+  }
   test.equal(Q.isPromiseLike(kewPromise), true, 'A Kew promise is promise-like')
   test.equal(Q.isPromiseLike(qPromise), true, 'A Q promise is promise-like')
   test.equal(Q.isPromiseLike(kewLikeObject), true, 'A pretend promise is a promise-like')
+  test.equal(Q.isPromiseLike(kewLikeFunction), true, 'A pretend function promise is a promise-like')
+
   test.done()
 }


### PR DESCRIPTION
Kew's current implementation of ```isPromiseLike()``` is deficient in that it fails to detect first-class function objects as potentially promises or thenables. I direct you to sections 1.1 and 1.2 of the Promises/A+ spec (emphasis added):

> 1.1 “promise” is an object *or function* with a then method whose behavior conforms to this specification.
> 1.2 “thenable” is an object *or function* that defines a then method.

This pull request handles this case and adds a test for it.
