### PR TITLE
Extended process.nextTick existence check

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -28,7 +28,7 @@ function nextTick (callback) {
   callback()
 }
 
-if (typeof process !== 'undefined') {
+if (typeof process !== 'undefined' && typeof process.nextTick === 'function') {
   nextTick = process.nextTick
 }
 


### PR DESCRIPTION
While using kew with react-native the environment has a fake process object that is missing the nextTick function.  This check means kew will keep using the polyfill.