### PR TITLE
Add Q.wrap() as convenience for returning/throwing plain values

### DIFF
--- a/kew.js
+++ b/kew.js
@@ -839,22 +839,39 @@ function bindPromise(fn, scope, var_args) {
   }
 }
 
+
+/**
+ * Provide a more idiomatic way to immediately return a promise and ensure all
+ * subsequent code (e.g., top-level `throw`s) is promisified.
+ *
+ * @param {function(...)} fn
+ * @param {Object=} opt_thisArg
+ * @return {!Promise}
+ */
+function wrap(fn, opt_thisArg) {
+  return resolve(null).then(function () {
+    return fn.call(opt_thisArg)
+  })
+}
+
+
 module.exports = {
   all: all,
+  allSettled: allSettled,
   bindPromise: bindPromise,
   defer: defer,
   delay: delay,
   fcall: fcall,
+  getNextTickFunction: getNextTickFunction,
   isPromise: isPromise,
   isPromiseLike: isPromiseLike,
   ncall: ncall,
   nfcall: nfcall,
   resolve: resolve,
   reject: reject,
+  setNextTickFunction: setNextTickFunction,
   spread: spread,
   stats: stats,
-  allSettled: allSettled,
+  wrap: wrap,
   Promise: Promise,
-  getNextTickFunction: getNextTickFunction,
-  setNextTickFunction: setNextTickFunction,
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kew",
   "description": "a lightweight promise library for node",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "homepage": "https://github.com/Medium/kew",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)",

--- a/test/static.js
+++ b/test/static.js
@@ -1,6 +1,47 @@
 var Q = require('../kew')
 var originalQ = require('q')
 
+// Create a promise with .wrap()
+exports.testQWrapReturnPlainValue = function (test) {
+  Q.wrap(function () {
+    return 'ok'
+  })
+    .then(function (val) {
+      test.equal(val, 'ok', 'Promise successfully returned')
+      test.done()
+    })
+}
+
+// Create a rejected promise with .wrap()
+exports.testQWrapThrowPlainError = function (test) {
+  Q.wrap(function () {
+    throw new Error('bad')
+  })
+    .then(function () {
+      test.fail('Promise should not resolve')
+    }, function (err) {
+      test.ok(err, 'Promise should have rejected')
+      test.done()
+    })
+}
+
+// Create a bound promise with .wrap()
+exports.testQWrapBound = function (test) {
+  function A() {
+    this.x = 'ok'
+  }
+  A.prototype.getX = function () {
+    return Q.wrap(function () {
+      return this.x
+    }, this)
+  }
+
+  new A().getX().then(function (val) {
+    test.equal(val, 'ok', 'Promise should be properly bound')
+    test.done()
+  })
+}
+
 // create a promise from a literal
 exports.testQResolve = function (test) {
   var val = "ok"


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'kyle-wrap'.

0e2caec74f4f28c78a2942850d1f0cf6a9fd54fd (2015-11-06 18:46:28 -0500)
Add Q.wrap() as convenience for returning/throwing plain values

R=@nicks